### PR TITLE
converts @EmbeddedMongoDbImport.file:String into @EmbeddedMongoDbImport.files:String[]

### DIFF
--- a/src/main/java/org/abelsromero/embedded/mongo/EmbeddedMongoDbImport.java
+++ b/src/main/java/org/abelsromero/embedded/mongo/EmbeddedMongoDbImport.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface EmbeddedMongoDbImport {
 
-    String file() default "";
+    String[] files();
 
     boolean jsonArray() default false;
 

--- a/src/test/java/org/abelsromero/embedded/mongo/EmbeddedMongoDbTest.java
+++ b/src/test/java/org/abelsromero/embedded/mongo/EmbeddedMongoDbTest.java
@@ -144,6 +144,22 @@ public class EmbeddedMongoDbTest {
     }
 
     @Test
+    public void should_init_collection_with_multiple_documents_from_multiple_files_using_repeated_annotation() {
+        // given
+        final EmbeddedMongoDb mongo = new EmbeddedMongoDb();
+        // when
+        mongo.starting(Description.createTestDescription(this.getClass(), "test_name",
+            new TestAnnotations().defaultEmbeddedConfiguration(),
+            new TestAnnotations().importMultipleJsonsAnnotations()
+        ));
+        // then
+        final MongoCollection<Document> collection = getDefaultCollection();
+        assertThat(collection.countDocuments()).isEqualTo(3l);
+        // cleanup
+        mongo.finished(null);
+    }
+
+    @Test
     public void should_fail_when_importing_documents_in_array_format_with_default_options() {
         // given
         final EmbeddedMongoDb mongo = new EmbeddedMongoDb();
@@ -168,7 +184,7 @@ public class EmbeddedMongoDbTest {
             new TestAnnotations().importMultipleJsonInArrayTrueAnnotation()));
         // then
         final MongoCollection<Document> collection = getDefaultCollection();
-        assertThat(collection.count()).isEqualTo(3l);
+        assertThat(collection.countDocuments()).isEqualTo(3l);
         // cleanup
         mongo.finished(null);
     }

--- a/src/test/java/org/abelsromero/embedded/mongo/test/TestAnnotations.java
+++ b/src/test/java/org/abelsromero/embedded/mongo/test/TestAnnotations.java
@@ -38,23 +38,27 @@ public class TestAnnotations {
         void skip() {
         }
 
-        @EmbeddedMongoDbImport(file = "single_document_data.json")
+        @EmbeddedMongoDbImport(files = "single_document_data.json")
         void importSingleDocument() {
         }
 
-        @EmbeddedMongoDbImport(file = "multiple_document_data.json")
+        @EmbeddedMongoDbImport(files = {"single_document_data.json", "multiple_document_data.json"})
+        void importMultipleJsons() {
+        }
+
+        @EmbeddedMongoDbImport(files = "multiple_document_data.json")
         void importMultipleDocuments() {
         }
 
-        @EmbeddedMongoDbImport(file = "multiple_document_data_in_array.json")
+        @EmbeddedMongoDbImport(files = "multiple_document_data_in_array.json")
         void importMultipleDocumentsInArray() {
         }
 
-        @EmbeddedMongoDbImport(file = "multiple_document_data_in_array.json", jsonArray = true)
+        @EmbeddedMongoDbImport(files = "multiple_document_data_in_array.json", jsonArray = true)
         void importMultipleDocumentsInArrayTrue() {
         }
 
-        @EmbeddedMongoDbImport(file = "non_existent_file.json")
+        @EmbeddedMongoDbImport(files = "non_existent_file.json")
         void nonExistentFile() {
         }
 
@@ -91,6 +95,10 @@ public class TestAnnotations {
 
     public EmbeddedMongoDbImport importMultipleJsonAnnotation() {
         return getImportAnnotationFrom("importMultipleDocuments");
+    }
+
+    public EmbeddedMongoDbImport importMultipleJsonsAnnotations() {
+        return getImportAnnotationFrom("importMultipleJsons");
     }
 
     public EmbeddedMongoDbImport importMultipleJsonInArrayAnnotation() {

--- a/src/test/resources/single_document_data.json
+++ b/src/test/resources/single_document_data.json
@@ -1,5 +1,5 @@
 {
-  _id: "c54kriewznasxf4scu5ylbnzve",
+  _id: "h69kriewznasxf4scu5ylbngqu",
   description: "this is a simple json document to be used with mongo import",
   timestamp: 1343779200000
 } 


### PR DESCRIPTION
BREAKING CHANGE
Allows importing multiple files for a single test.

Changes:
* Changes `file` in `@EmbeddedMongoDbImport` type from String to String[]
* Changes `file` in `@EmbeddedMongoDbImport` name to `files`
